### PR TITLE
Expose the library build hash from FindCuvis

### DIFF
--- a/FindCuvis.cmake
+++ b/FindCuvis.cmake
@@ -68,6 +68,14 @@ else()
   function(get_library_version LIB_PATH OUTPUT_VARIABLE)
     set(GET_VERSION_SOURCE "${CMAKE_CURRENT_LIST_DIR}/helper/get_version.c")
 
+    # The probe output is the only evidence of which library is really there, so it must
+    # never be served from a cache written for a different SDK. Keying on the library
+    # path or timestamp would not do: on Windows that is the import library, while the
+    # probe executable loads cuvis.dll off PATH, and the two can diverge.
+    unset(GET_VERSION_RUN_RESULT CACHE)
+    unset(GET_VERSION_COMPILE_RESULT CACHE)
+    unset(${OUTPUT_VARIABLE} CACHE)
+
 	try_run(
 		GET_VERSION_RUN_RESULT GET_VERSION_COMPILE_RESULT
         ${CMAKE_BINARY_DIR}/try_compile
@@ -101,13 +109,21 @@ else()
   set(lib_version_MINOR ${CMAKE_MATCH_2})
   set(lib_version_PATCH ${CMAKE_MATCH_3})
 
-  # Check the library version against the required version
-  set(CUVIS_VERSION_STRING "${lib_version_MAJOR}.${lib_version_MINOR}.${lib_version_PATCH}")
+  # The library reports "CUBERT SDK v. X.Y.Z build: <hash>". The version alone does not
+  # identify a build, so keep the hash for the mismatch diagnostics in the bindings. An
+  # absent build segment leaves it empty rather than failing the configure.
+  set(build_hash "")
+  string(REGEX MATCH "build: ([0-9a-fA-F]+)" LIB_BUILD_MATCH "${LIB_VERSION}")
+  if(LIB_BUILD_MATCH)
+    set(build_hash "${CMAKE_MATCH_1}")
+  endif()
 
   # Provide configuration information for find_package(Cuvis)
 
   set(Cuvis_FOUND TRUE CACHE INTERNAL "")
   set(Cuvis_VERSION "${lib_version_MAJOR}.${lib_version_MINOR}.${lib_version_PATCH}" CACHE INTERNAL "")
+  set(Cuvis_VERSION_STRING "${LIB_VERSION}" CACHE INTERNAL "")
+  set(Cuvis_BUILD_HASH "${build_hash}" CACHE INTERNAL "")
   set(Cuvis_INCLUDE_DIRS "${Cuvis_INCLUDE_DIR}" CACHE INTERNAL "")
   set(Cuvis_LIBRARIES "cuvis::c" CACHE INTERNAL "")
 


### PR DESCRIPTION
## Why

`cuvis_version()` reports `CUBERT SDK v. X.Y.Z build: <hash>`, but the find module parsed out the three version digits and discarded the rest.

The version moves rarely, so two libraries can both report `3.5.3` and still be entirely different builds. That is not hypothetical: on my machine the installed `cuvis.dll` and a staged one both report `3.5.3`, differ by 154 MB, and export different symbol sets.

This is exactly the case the SWIG bindings cannot currently diagnose. A binding records the version it was compiled against, compares it against the loaded library, finds them equal, and reports nothing, while a CUDA call fails because the symbol is not there.

## What

Keep the hash and export it, so a binding can bake it into its build information and report a build-level mismatch. A differing hash is not an error; it is debugging information.

| Variable | Example | Status |
| --- | --- | --- |
| `Cuvis_VERSION` | `3.5.3` | unchanged, still the `VERSION_VAR` |
| `Cuvis_VERSION_STRING` | `CUBERT SDK v. 3.5.3 build: 0f416fb6...` | the full string as found |
| `Cuvis_BUILD_HASH` | `0f416fb6327f26644290b554c9b16050a515b89d` | new |

There is no established CMake variable for a build or VCS identifier, so only the raw-string variable follows a convention: `<Pkg>_VERSION_STRING` is what `FindZLIB` and `FindPNG` use for the version exactly as found. It is deliberately not passed as `VERSION_VAR`, which would break range requests such as `find_package(Cuvis 3.4...<3.6)`. It replaces the uncached, unprefixed `CUVIS_VERSION_STRING` that no consumer could read.

An absent `build:` segment leaves `Cuvis_BUILD_HASH` empty and configures normally, so an older or newer library that stops printing the hash does not break the build.

## Also in here

The `try_run` result caches are now dropped before probing.

Previously a reconfigure into an existing build directory served the version recorded for whichever SDK was installed when that directory was first configured. That is tolerable for a version that rarely moves, but not for a hash whose only purpose is answering whether two libraries are the same build, where a stale value is a confident wrong answer.

Keying the cache on the library path or timestamp would not help: on Windows `Cuvis_LIBRARY` is the import library, while the probe executable loads `cuvis.dll` off `PATH`, and the two can diverge. Re-running is the only correct answer, and it costs one compile-and-run per configure.

## Verified

- Configure against an installed 3.5.3 SDK yields `Cuvis_VERSION=3.5.3`, `Cuvis_VERSION_STRING=CUBERT SDK v. 3.5.3 build: 0f416fb6327f26644290b554c9b16050a515b89d`, `Cuvis_BUILD_HASH=0f416fb6327f26644290b554c9b16050a515b89d`.
- `find_package(Cuvis 3.4...<3.6 REQUIRED)` still resolves, confirming `VERSION_VAR` was not repointed at the raw string.
- Poisoning `LIB_VERSION` and `Cuvis_BUILD_HASH` in an existing `CMakeCache.txt` and reconfiguring restores both correctly, confirming the re-probe.
- Configuring against a second, differently built 3.5.3 SDK yields the same version and hash `a26a0635e22c854ef49c5167ba622b6fab605948`, which is the mismatch this change exists to surface.
- A version string with no `build:` segment, and an empty string, both yield an empty hash rather than a configure failure.
- End to end through the Python binding: built against one SDK and run against the other, the loaded library is now identified as a different build of the same version, and the missing-symbol error names both hashes.

## Follow-up, not in this PR

`cuvis.swig` needs to define `CUVIS_BINDING_BUILT_HASH` from `Cuvis_BUILD_HASH` and expose it, and the bindings need to surface it. Those changes are prepared and depend on this one.

## Defects noticed while in here, deliberately left alone

- Line 79 passes `-DINCLUDE_DIRECTORIES=${Cuivs_INCLUDE_DIR}`, a typo that expands empty. The probe only compiles because `cuvis::c` carries the include directory as an interface property. `FindCuvisCpp.cmake` spells it correctly.
- `Cuvis_FOUND` is set to `TRUE` in the cache before `find_package_handle_standard_args` runs, and a missing library aborts with `FATAL_ERROR`. The module can never report "not found", so `find_package(Cuvis QUIET)` is impossible.
